### PR TITLE
ui tests now use correct wait for view

### DIFF
--- a/src/main/java/io/reist/visum/model/CachedService.java
+++ b/src/main/java/io/reist/visum/model/CachedService.java
@@ -46,10 +46,12 @@ public abstract class CachedService<T> extends BaseService<T> {
      */
     @Override
     public final Observable<VisumResponse<List<T>>> list() {
-        return Observable.merge(
-                local.list(),
-                remote.list().compose(new SaveAndEmitErrorsListTransformer<>(local)))
-                .filter(new ListResponseFilter<>());
+        return Observable
+                .merge(
+                        local.list(),
+                        remote.list().compose(new SaveAndEmitErrorsListTransformer<>(local)))
+                .filter(new ListResponseFilter<>())
+                .first();
     }
 
     /**
@@ -57,10 +59,13 @@ public abstract class CachedService<T> extends BaseService<T> {
      */
     @Override
     public final Observable<VisumResponse<T>> byId(Long id) {
-        return Observable.merge(
-                local.byId(id),
-                remote.byId(id).compose(new SaveAndEmitErrorsTransformer<>(local)))
-                .filter(new ResponseFilter<>());
+        return Observable
+                .merge(
+                        local.byId(id),
+                        remote.byId(id).compose(new SaveAndEmitErrorsTransformer<>(local))
+                )
+                .filter(new ResponseFilter<>())
+                .first();
     }
 
     /**
@@ -152,9 +157,7 @@ public abstract class CachedService<T> extends BaseService<T> {
 
     public static class SaveAndEmitErrorsListTransformer<T>
             extends SaveTransformer<T>
-            implements Observable.Transformer<VisumResponse<List<T>>, VisumResponse<List<T>>>
-
-    {
+            implements Observable.Transformer<VisumResponse<List<T>>, VisumResponse<List<T>>> {
 
         public SaveAndEmitErrorsListTransformer(VisumService<T> service) {
             super(service);

--- a/src/main/java/io/reist/visum/view/VisumFragment.java
+++ b/src/main/java/io/reist/visum/view/VisumFragment.java
@@ -142,9 +142,21 @@ public abstract class VisumFragment<P extends VisumPresenter> extends Fragment i
     @SuppressWarnings("unchecked") //todo setView should be type safe call
     @Override
     public void detachPresenter() {
-        if (getPresenter() != null)
-            getPresenter().setView(null);
+        final P presenter = getPresenter();
+        if (presenter != null)
+            presenter.setView(null);
     }
 
     //endregion
+
+    @Override
+    public void onHiddenChanged(boolean hidden) {
+        super.onHiddenChanged(hidden);
+        if (hidden) {
+            detachPresenter();
+        } else {
+            attachPresenter();
+        }
+    }
+
 }


### PR DESCRIPTION
Related to https://dreams.atlassian.net/browse/ZAN-130

changes:
- added first() to CachedService because we don't want to reload a repo to edit twice after we pick one
- onHiddenChanged reattaches presenter of the previous fragment after navigating back

UI tests of mvp-sandbox won't run correctly without this PR