### PR TITLE
Fail test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     // junit tests
 
     testCompile 'junit:junit:4.12'
-    testCompile "org.robolectric:robolectric:3.1.4"
+    testCompile "org.robolectric:robolectric:3.3.2"
     testCompile "org.mockito:mockito-core:2.2.24"
     testCompile 'org.assertj:assertj-core:3.6.0'
 

--- a/demo/src/test/java/io/reist/sandbox/result/view/ResultActivityTest.java
+++ b/demo/src/test/java/io/reist/sandbox/result/view/ResultActivityTest.java
@@ -1,0 +1,40 @@
+package io.reist.sandbox.result.view;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import io.reist.sandbox.BuildConfig;
+
+import static android.os.Build.VERSION_CODES.M;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+/**
+ * Created by defuera on 22/05/2017.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(
+        constants = BuildConfig.class,
+        sdk = M
+)
+public class ResultActivityTest {
+
+    private ResultActivity view;
+
+    @Before
+    public void setUp() throws Exception {
+        view = Robolectric
+                .buildActivity(ResultActivity.class)
+                .create()
+                .get();
+    }
+
+    @Test
+    public void getPresenter() {
+        assertThat(view.getPresenter()).isNotNull();
+    }
+
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 
 }


### PR DESCRIPTION
Для того, что бы не было ошибки  ResourceNotFoundException и тесты заработали я в `Run` -> `edit configurations` указываю `Working directory`: 

![image](https://cloud.githubusercontent.com/assets/1181883/26329185/4ca22e10-3f46-11e7-8d9f-408b62d4a9c1.png)



В результате запуска теста `ResultActivityTest` я получаю stacktrace:

```
java.lang.RuntimeException: java.lang.IllegalAccessException: Class io.reist.visum.VisumClientHelper can not access a member of class io.reist.sandbox.app.DaggerSandboxComponent$ResultComponentImpl with modifiers "public"

	at io.reist.visum.VisumClientHelper.onCreate(VisumClientHelper.java:86)
	at io.reist.visum.view.VisumViewHelper.onCreate(VisumViewHelper.java:77)
	at io.reist.visum.view.VisumActivity.onStartClient(VisumActivity.java:61)
	at io.reist.visum.view.VisumActivity.onCreate(VisumActivity.java:107)
	at io.reist.sandbox.result.view.ResultActivity.onCreate(ResultActivity.java:69)
	at android.app.Activity.performCreate(Activity.java:6251)
	at org.robolectric.util.ReflectionHelpers.callInstanceMethod(ReflectionHelpers.java:231)
	at org.robolectric.android.controller.ActivityController$1.run(ActivityController.java:140)
	at org.robolectric.shadows.ShadowLooper.runPaused(ShadowLooper.java:362)
	at org.robolectric.shadows.CoreShadowsAdapter$2.runPaused(CoreShadowsAdapter.java:40)
	at org.robolectric.android.controller.ActivityController.create(ActivityController.java:137)
	at org.robolectric.android.controller.ActivityController.create(ActivityController.java:147)
	at io.reist.sandbox.result.view.ResultActivityTest.setUp(ResultActivityTest.java:31)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.robolectric.internal.SandboxTestRunner$2.evaluate(SandboxTestRunner.java:209)
	at org.robolectric.internal.SandboxTestRunner.runChild(SandboxTestRunner.java:109)
	at org.robolectric.internal.SandboxTestRunner.runChild(SandboxTestRunner.java:36)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.robolectric.internal.SandboxTestRunner$1.evaluate(SandboxTestRunner.java:63)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:117)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:42)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:262)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:84)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: java.lang.IllegalAccessException: Class io.reist.visum.VisumClientHelper can not access a member of class io.reist.sandbox.app.DaggerSandboxComponent$ResultComponentImpl with modifiers "public"
	at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:102)
	at java.lang.reflect.AccessibleObject.slowCheckMemberAccess(AccessibleObject.java:296)
	at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:288)
	at java.lang.reflect.Method.invoke(Method.java:491)
	at io.reist.visum.VisumClientHelper.onCreate(VisumClientHelper.java:76)
	at io.reist.visum.view.VisumViewHelper.onCreate(VisumViewHelper.java:77)
	at io.reist.visum.view.VisumActivity.onStartClient(VisumActivity.java:61)
	at io.reist.visum.view.VisumActivity.onCreate(VisumActivity.java:107)
	at io.reist.sandbox.result.view.ResultActivity.onCreate(ResultActivity.java:69)
	at android.app.Activity.$$robo$$performCreate(Activity.java:6251)
	at android.app.Activity.performCreate(Activity.java)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.robolectric.util.ReflectionHelpers.callInstanceMethod(ReflectionHelpers.java:231)
	at org.robolectric.android.controller.ActivityController$1.run(ActivityController.java:140)
	at org.robolectric.shadows.ShadowLooper.runPaused(ShadowLooper.java:362)
	at org.robolectric.shadows.CoreShadowsAdapter$2.runPaused(CoreShadowsAdapter.java:40)
	at org.robolectric.android.controller.ActivityController.create(ActivityController.java:137)
	at org.robolectric.android.controller.ActivityController.create(ActivityController.java:147)
	at io.reist.sandbox.result.view.ResultActivityTest.setUp(ResultActivityTest.java:31)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
```
